### PR TITLE
Docker + Slack 

### DIFF
--- a/Docker+Slack/Dockerfile
+++ b/Docker+Slack/Dockerfile
@@ -1,0 +1,2 @@
+FROM ruby:2.1-onbuild
+CMD ["ruby","./slacker.rb"]

--- a/Docker+Slack/Gemfile
+++ b/Docker+Slack/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'docker-api'
+gem 'slack-notifier'

--- a/Docker+Slack/Gemfile.lock
+++ b/Docker+Slack/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    docker-api (1.22.4)
+      excon (>= 0.38.0)
+      json
+    excon (0.45.4)
+    json (1.8.3)
+    slack-notifier (1.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  docker-api
+  slack-notifier
+
+BUNDLED WITH
+   1.10.6

--- a/Docker+Slack/README.md
+++ b/Docker+Slack/README.md
@@ -1,6 +1,11 @@
 # Docker+Slack
 
-A Slack integration to notify Docker events.
+A Slack integration to notify Docker events (starting and stopping containers for now).
+
+## Requirements
++ Docker
++ Docker Compose
++ Slack account
 
 ## How to get started
 
@@ -8,7 +13,6 @@ A Slack integration to notify Docker events.
 
 + Update `SLACK_URL` environemt variable in `docker-compose.yml` with the ` Webhook URL` you just got from Slack. 
 
-+ Run it 
-```
-docker-compose up -d
-```
++ Run it using Docker Compose : `docker-compose up -d`
+
+

--- a/Docker+Slack/README.md
+++ b/Docker+Slack/README.md
@@ -1,0 +1,14 @@
+# Docker+Slack
+
+A Slack integration to notify Docker events.
+
+## How to get started
+
++ Set up [an incoming WebHook integration](https://my.slack.com/services/new/incoming-webhook) and get the Webhook URL.
+
++ Update `SLACK_URL` environemt variable in `docker-compose.yml` with the ` Webhook URL` you just got from Slack. 
+
++ Run it 
+```
+docker-compose up -d
+```

--- a/Docker+Slack/README.md
+++ b/Docker+Slack/README.md
@@ -2,6 +2,8 @@
 
 A Slack integration to notify Docker events (starting and stopping containers for now).
 
+![slacker-1.0](https://www.dropbox.com/s/5lfvkta4mj3mss9/Slack.png)
+
 ## Requirements
 + Docker
 + Docker Compose

--- a/Docker+Slack/README.md
+++ b/Docker+Slack/README.md
@@ -2,7 +2,7 @@
 
 A Slack integration to notify Docker events (starting and stopping containers for now).
 
-![slacker-1.0](https://www.dropbox.com/s/5lfvkta4mj3mss9/Slack.png)
+![slacker-1.0](http://i.imgur.com/nSoNOQB.png)
 
 ## Requirements
 + Docker

--- a/Docker+Slack/docker-compose.yml
+++ b/Docker+Slack/docker-compose.yml
@@ -3,4 +3,4 @@ slacker:
  volumes:
     - /var/run/docker.sock:/var/run/docker.sock
  environment:
-    - SLACK_URL=https://hooks.slack.com/services/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
+    - SLACK_URL=https://hooks.slack.com/services/T0543....BdMCX3AFP7GSANBnNFRY

--- a/Docker+Slack/docker-compose.yml
+++ b/Docker+Slack/docker-compose.yml
@@ -1,0 +1,6 @@
+slacker:
+ build: .
+ volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+ environment:
+    - SLACK_URL=https://hooks.slack.com/services/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

--- a/Docker+Slack/slacker.rb
+++ b/Docker+Slack/slacker.rb
@@ -1,57 +1,20 @@
 require 'docker'
 require 'slack-notifier'
 
-puts(ENV["SLACK_URL"])
 
 notifier = Slack::Notifier.new(ENV["SLACK_URL"])
 
-puts "Booting"
-
 Docker::Event.stream do |event|
-	container = Docker::Container.get(event.id)
-	hostname = container.json["Config"]["Hostname"]
-
-	#puts "hostname: #{container.json}"
-	container_name = container.json["Name"]
-	puts "name: #{container_name}"
-
-        pcontainer = {id: hostname, name: "C1", image:"Ubuntu 14.04"}
-
-	if event.status == "stop"
-		#pevent = {level: "warning", description: "Stopped"}
-		notifier.ping "Container #{hostname} was Stopped"
-		puts "Notifying Slack"
-	elsif event.status == "start"
-		#pevent = {level: "good", description: "Started"
-		notifier.ping "Container #{hostname} was Started"
-		puts "Notifying Slack"
-	end
-
-	#DockerNotifier.notify(qevent, qcontainer)
-end
-
-class DockerNotifier
-
-	def self.notify(event, container)
-		notifier = Slack::Notifier.new "https://hooks.slack.com/services/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"
-
-		message = {
-			fallback: "Container #{container[:id]} was #{event[:description]}",
-			color: "#{event[:level]}",
-			fields: [
-				{
-					title: "Name",
-					value: "#{container[:name]}",
-					short: false
-				},
-				{
-					title: "Image",
-					value: "#{container[:image]}",
-					short: false
-				}
-			]
-		}
-		notifier.ping "Container #{container[:id]} was #{event[:description]}", attachments: [message]
-	end
-
+        puts event
+        container = Docker::Container.get(event.id)
+        if container 
+        	hostname = container.json["Config"]["Hostname"]
+	        if event.status && event.status == "stop"
+	                notifier.ping "Container #{hostname} was Stopped"
+	                puts "Container event.id} was Stopped"
+	        elsif event.status && event.status == "start"
+	                notifier.ping "Container #{hostname} was Started"
+	                puts "Container event.id} was Started"
+	        end
+        end
 end

--- a/Docker+Slack/slacker.rb
+++ b/Docker+Slack/slacker.rb
@@ -1,0 +1,57 @@
+require 'docker'
+require 'slack-notifier'
+
+puts(ENV["SLACK_URL"])
+
+notifier = Slack::Notifier.new(ENV["SLACK_URL"])
+
+puts "Booting"
+
+Docker::Event.stream do |event|
+	container = Docker::Container.get(event.id)
+	hostname = container.json["Config"]["Hostname"]
+
+	#puts "hostname: #{container.json}"
+	container_name = container.json["Name"]
+	puts "name: #{container_name}"
+
+        pcontainer = {id: hostname, name: "C1", image:"Ubuntu 14.04"}
+
+	if event.status == "stop"
+		#pevent = {level: "warning", description: "Stopped"}
+		notifier.ping "Container #{hostname} was Stopped"
+		puts "Notifying Slack"
+	elsif event.status == "start"
+		#pevent = {level: "good", description: "Started"
+		notifier.ping "Container #{hostname} was Started"
+		puts "Notifying Slack"
+	end
+
+	#DockerNotifier.notify(qevent, qcontainer)
+end
+
+class DockerNotifier
+
+	def self.notify(event, container)
+		notifier = Slack::Notifier.new "https://hooks.slack.com/services/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"
+
+		message = {
+			fallback: "Container #{container[:id]} was #{event[:description]}",
+			color: "#{event[:level]}",
+			fields: [
+				{
+					title: "Name",
+					value: "#{container[:name]}",
+					short: false
+				},
+				{
+					title: "Image",
+					value: "#{container[:image]}",
+					short: false
+				}
+			]
+		}
+		notifier.ping "Container #{container[:id]} was #{event[:description]}", attachments: [message]
+	end
+
+end


### PR DESCRIPTION
# Docker+Slack

A Slack integration to notify Docker events (starting and stopping containers for now).

![slacker-1.0](http://i.imgur.com/nSoNOQB.png)
## Requirements
- Docker
- Docker Compose
- Slack account
## How to get started
- Set up [an incoming WebHook integration](https://my.slack.com/services/new/incoming-webhook) and get the Webhook URL.
- Update `SLACK_URL` environemt variable in `docker-compose.yml` with the `Webhook URL` you just got from Slack. 
- Run it using Docker Compose : `docker-compose up -d`
